### PR TITLE
feat: build rift from source (main) and update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,19 +22,57 @@
           "nix-ai-tools",
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": [
+          "nix-ai-tools",
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1769353768,
-        "narHash": "sha256-zI+7cbMI4wMIR57jMjDSEsVb3grapTnURDxxJPYFIW0=",
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "c7da5c70ad1c9b60b6f5d4f674fbe205d48d8f6c",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "nix-ai-tools",
+          "flake-parts"
+        ],
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "nix-ai-tools",
+          "nixpkgs"
+        ],
+        "systems": [
+          "nix-ai-tools",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "nix-ai-tools",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776182890,
+        "narHash": "sha256-+/VOe8XGq5klpU+I19D+3TcaR7o+Cwbq67KNF7mcFak=",
+        "owner": "Mic92",
+        "repo": "bun2nix",
+        "rev": "648d293c51e981aec9cb07ba4268bc19e7a8c575",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "ref": "catalog-support",
+        "repo": "bun2nix",
         "type": "github"
       }
     },
@@ -59,6 +97,27 @@
       }
     },
     "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-ai-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
           "nixvim",
@@ -100,18 +159,36 @@
         "type": "github"
       }
     },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "nix-ai-tools": {
       "inputs": {
         "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1770616720,
-        "narHash": "sha256-NY7yFg3ZG0fzseC4SK/TQjgaODczuvCDtJZNsBmN2QU=",
+        "lastModified": 1776930671,
+        "narHash": "sha256-UUl4byloglJGwC8H252NaMl3U34i42Xr2++4qqo5vc0=",
         "owner": "numtide",
         "repo": "nix-ai-tools",
-        "rev": "09019dadd541051fc11f5008b56f4e8a14d2df4c",
+        "rev": "cd7fb61718308304f56b6a74deddcbe898842d8c",
         "type": "github"
       },
       "original": {
@@ -141,11 +218,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -188,7 +265,7 @@
     },
     "nixvim": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -256,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750618568,
-        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
+        "lastModified": 1773000227,
+        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
+        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
         "type": "github"
       },
       "original": {
@@ -66,34 +66,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -104,45 +86,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1750798083,
-        "narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
+        "lastModified": 1773093840,
+        "narHash": "sha256-u/96NoAyN8BSRuM3ZimGf7vyYgXa3pLx4MYWjokuoH4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
+        "rev": "bb014746edb2a98d975abde4dd40fa240de4cf86",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "ref": "master",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "ixx": {
-      "inputs": {
-        "flake-utils": [
-          "nixvim",
-          "nuschtosSearch",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixvim",
-          "nuschtosSearch",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1748294338,
-        "narHash": "sha256-FVO01jdmUNArzBS7NmaktLdGA5qA3lUMJ4B7a05Iynw=",
-        "owner": "NuschtOS",
-        "repo": "ixx",
-        "rev": "cc5f390f7caf265461d4aab37e98d2292ebbdb85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "ref": "v0.0.8",
-        "repo": "ixx",
         "type": "github"
       }
     },
@@ -218,11 +172,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1750898778,
-        "narHash": "sha256-DXI7+SKDlTyA+C4zp0LoIywQ+BfdH5m4nkuxbWgV4UU=",
+        "lastModified": 1772956932,
+        "narHash": "sha256-M0yS4AafhKxPPmOHGqIV0iKxgNO8bHDWdl1kOwGBwRY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "322d8a3c6940039f7cff179a8b09c5d7ca06359d",
+        "rev": "608d0cadfed240589a7eea422407a547ad626a14",
         "type": "github"
       },
       "original": {
@@ -238,43 +192,19 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nuschtosSearch": "nuschtosSearch",
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750879244,
-        "narHash": "sha256-ClV6rZbPnd5wIcBYNiCdrbhtSzY6dwPRA4Z/z1cFcyo=",
+        "lastModified": 1772402258,
+        "narHash": "sha256-3DmCFOdmbkFML1/G9gj8Wb+rCCZFPOQtNoMCpqOF8SA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f0764db7212003520341ac10ddcee50e9c458a6f",
+        "rev": "21ae25e13b01d3b4cdc750b5f9e7bad68b150c10",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "nixvim",
-        "type": "github"
-      }
-    },
-    "nuschtosSearch": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "ixx": "ixx",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749730855,
-        "narHash": "sha256-L3x2nSlFkXkM6tQPLJP3oCBMIsRifhIDPMQQdHO5xWo=",
-        "owner": "NuschtOS",
-        "repo": "search",
-        "rev": "8dfe5879dd009ff4742b668d9c699bc4b9761742",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "repo": "search",
         "type": "github"
       }
     },
@@ -304,21 +234,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix/common/packages.nix
+++ b/nix/common/packages.nix
@@ -27,7 +27,7 @@ let
     jq
     act
     nodePackages.git-run
-    gitAndTools.delta
+    delta
     tree-sitter
     luaformatter
     eslint_d
@@ -49,7 +49,7 @@ let
     nil
   ];
 
-  commandLineTools = [ autojump btop eza gtop neofetch nix-tree ];
+  commandLineTools = [ autojump btop eza gtop fastfetch nix-tree ];
 
   node = nodejs_20;
   # node = nodejs_24;

--- a/nix/configs/skhd-module.nix
+++ b/nix/configs/skhd-module.nix
@@ -4,17 +4,14 @@ let
   wmUtils = import ./window-manager/wm-utils.nix { inherit lib; };
   modifiers = import ../darwin/modifiers.nix;
 
-  directKeybinds = {
-    "${modifiers.super}+l" = "pmset displaysleepnow";
-  };
+  directKeybinds = { "${modifiers.super}+l" = "pmset displaysleepnow"; };
   wmGenericKeybinds =
     import ./window-manager/keybinds/window-manager-keybinds.nix {
       inherit lib pkgs modifiers;
     };
-  wmCommandMap = (import ./window-manager/keybinds/rift-keybinds.nix {
-    inherit lib pkgs;
-  });
-  # wmCommandMap = (import ./window-manager/keybinds/yabai-keybinds.nix {
+  wmCommandMap =
+    (import ./window-manager/keybinds/yabai-keybinds.nix { inherit lib pkgs; });
+  # wmCommandMap = (import ./window-manager/keybinds/rift-keybinds.nix {
   #   inherit lib pkgs;
   # });
 
@@ -30,21 +27,18 @@ let
     in if modifiers == [ ] then keyName else modifierStr + " - " + keyName;
 
   # Blacklist certain applications
-  blacklistApps = [
-    "parsecd"
-    "Parsec"
-    "Moonlight"
-    "moonlight"
-  ];
-  
-  blacklistConfig = ".blacklist [\n    " + 
-    (lib.concatStringsSep "\n    " (map (app: "\"${app}\"") blacklistApps)) + 
-    "\n]";
+  blacklistApps = [ "parsecd" "Parsec" "Artemis" "Moonlight" "moonlight" ];
+
+  blacklistConfig = ".blacklist [\n    "
+    + (lib.concatStringsSep "\n    " (map (app: ''"${app}"'') blacklistApps))
+    + ''
+
+      ]'';
 
   keybindLines = lib.concatStringsSep "\n"
     (lib.mapAttrsToList (k: v: (convertToSkhdSyntax k) + " : " + v)
       allKeybinds);
-  
+
   lines = blacklistConfig + "\n\n" + keybindLines;
 
 in {

--- a/nix/configs/vim/plugins-treesitter.lua
+++ b/nix/configs/vim/plugins-treesitter.lua
@@ -1,8 +1,5 @@
 -- Treesitter configuration
-require("nvim-treesitter.configs").setup {
-    autotag = {enable = true},
-    highlight = {enable = true}
-}
+-- Grammars are installed by Nix (withAllGrammars); highlight is enabled by default.
 
 -- Tree-sitter language injection setup
 require("tree-sitter-language-injection").setup({

--- a/nix/configs/window-manager/keybinds/yabai-keybinds.nix
+++ b/nix/configs/window-manager/keybinds/yabai-keybinds.nix
@@ -1,13 +1,18 @@
 { lib, pkgs ? import <nixpkgs> { } }: {
-  focus_left = "yabai -m window --focus west";
-  focus_down = "yabai -m window --focus south";
-  focus_up = "yabai -m window --focus north";
-  focus_right = "yabai -m window --focus east";
+  focus_left = "yabai -m window --focus west || yabai -m display --focus west";
+  focus_down =
+    "yabai -m window --focus south || yabai -m display --focus south";
+  focus_up = "yabai -m window --focus north || yabai -m display --focus north";
+  focus_right = "yabai -m window --focus east || yabai -m display --focus east";
 
-  move_left = "yabai -m window --warp west";
-  move_down = "yabai -m window --warp south";
-  move_up = "yabai -m window --warp north";
-  move_right = "yabai -m window --warp east";
+  move_left =
+    "yabai -m window --warp west || yabai -m window --display west --focus";
+  move_down =
+    "yabai -m window --warp south || yabai -m window --display south --focus";
+  move_up =
+    "yabai -m window --warp north || yabai -m window --display north --focus";
+  move_right =
+    "yabai -m window --warp east || yabai -m window --display east --focus";
 
   move_node_to_workspace_1 = "yabai -m window --space 1";
   move_node_to_workspace_2 = "yabai -m window --space 2";
@@ -26,7 +31,7 @@
   toggle_fullscreen = "yabai -m window --toggle zoom-fullscreen";
   toggle_floating = "yabai -m window --toggle float";
   close_window = "yabai -m window --close";
-  open_terminal = "open -a kitty";
+  open_terminal = "open -na kitty";
 
   # Tree manipulation commands
   rotate_tree = "yabai -m space --rotate 90";

--- a/nix/configs/window-manager/rift.nix
+++ b/nix/configs/window-manager/rift.nix
@@ -3,14 +3,14 @@
 let
   riftConfig = ''
     [settings]
-    animate = true
+    animate = false
     animation_duration = 0.3
     animation_fps = 100.0
     animation_easing = "ease_in_out"
     focus_follows_mouse = true
     mouse_follows_focus = true
-    mouse_hides_on_focus = true
-    hot_reload = true
+    mouse_hides_on_focus = false
+    hot_reload = false
     default_disable = false
     run_on_start = [
       "${pkgs.rift}/bin/rift-cli subscribe cli --event workspace_changed --command sh --args -c --args '${pkgs.sketchybar}/bin/sketchybar --trigger wm_workspace_changed WM_WORKSPACE_NAME=\"$RIFT_WORKSPACE_NAME\"'",
@@ -20,7 +20,7 @@ let
     mode = "bsp"
 
     [settings.layout.gaps.outer]
-    top = 10
+    top = 34
     left = 10
     bottom = 10
     right = 10
@@ -28,6 +28,9 @@ let
     [settings.layout.gaps.inner]
     horizontal = 10
     vertical = 10
+
+    [settings.layout.gaps.per_display."37D8832A-2D66-02CA-B9F7-8F30A301B230".outer]
+    top = 10
 
     [virtual_workspaces]
     enabled = true
@@ -57,88 +60,4 @@ let
 
     [keys]
   '';
-in {
-  home.file.".config/rift/config.toml" = {
-    text = riftConfig;
-  };
-
-  home.file."Applications/Rift.app/Contents/Info.plist" = {
-    text = ''
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>CFBundleInfoDictionaryVersion</key>
-        <string>6.0</string>
-        <key>CFBundleDevelopmentRegion</key>
-        <string>en</string>
-        <key>CFBundleName</key>
-        <string>Rift</string>
-        <key>CFBundleDisplayName</key>
-        <string>Rift</string>
-        <key>CFBundleIdentifier</key>
-        <string>local.nix.Rift</string>
-        <key>CFBundleSignature</key>
-        <string>????</string>
-        <key>CFBundleVersion</key>
-        <string>1.0</string>
-        <key>CFBundleShortVersionString</key>
-        <string>1.0</string>
-        <key>CFBundlePackageType</key>
-        <string>APPL</string>
-        <key>CFBundleExecutable</key>
-        <string>Rift</string>
-      </dict>
-      </plist>
-    '';
-  };
-
-  home.file."Applications/Rift.app/Contents/PkgInfo" = {
-    text = "APPL????";
-  };
-
-  home.file."Applications/Rift.app/Contents/MacOS/Rift" = {
-    source = "${pkgs.rift}/bin/rift";
-    executable = true;
-  };
-
-  home.file."Applications/Skhd.app/Contents/Info.plist" = {
-    text = ''
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>CFBundleInfoDictionaryVersion</key>
-        <string>6.0</string>
-        <key>CFBundleDevelopmentRegion</key>
-        <string>en</string>
-        <key>CFBundleName</key>
-        <string>Skhd</string>
-        <key>CFBundleDisplayName</key>
-        <string>Skhd</string>
-        <key>CFBundleIdentifier</key>
-        <string>local.nix.Skhd</string>
-        <key>CFBundleSignature</key>
-        <string>????</string>
-        <key>CFBundleVersion</key>
-        <string>1.0</string>
-        <key>CFBundleShortVersionString</key>
-        <string>1.0</string>
-        <key>CFBundlePackageType</key>
-        <string>APPL</string>
-        <key>CFBundleExecutable</key>
-        <string>Skhd</string>
-      </dict>
-      </plist>
-    '';
-  };
-
-  home.file."Applications/Skhd.app/Contents/PkgInfo" = {
-    text = "APPL????";
-  };
-
-  home.file."Applications/Skhd.app/Contents/MacOS/Skhd" = {
-    source = "${pkgs.skhd}/bin/skhd";
-    executable = true;
-  };
-}
+in { home.file.".config/rift/config.toml" = { text = riftConfig; }; }

--- a/nix/darwin/packages.nix
+++ b/nix/darwin/packages.nix
@@ -12,8 +12,9 @@ in {
     ccusage
     karabiner-elements
     macfuse-stubs
-    # yabai
-    rift
+    yabai
+    # rift disabled in favour of yabai, keep package available
+    # rift
 
     # iOS Development tools
     git-lfs

--- a/nix/darwin/services.nix
+++ b/nix/darwin/services.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   janky-borders = import ../derivations/jankyBorders.nix {
-    inherit (pkgs) stdenv fetchFromGitHub gcc make darwin;
+    inherit (pkgs) stdenv fetchFromGitHub gcc make darwin apple-sdk_15;
   };
 
 in {
@@ -31,7 +31,13 @@ in {
   #   serviceConfig.RunAtLoad = true;
   # };
 
-  # Rift is managed by its own launchd service (rift service install/start).
+  # Rift is already started by the app LaunchAgent (git.acsandmann.rift).
+  # Keeping both this agent and the app agent enabled spawns two Rift instances.
+  # launchd.user.agents.rift = {
+  #   serviceConfig.ProgramArguments = [ "${pkgs.rift}/bin/rift" ];
+  #   serviceConfig.KeepAlive = true;
+  #   serviceConfig.RunAtLoad = true;
+  # };
 
   # Ne fonctionne pas avec les arrows / tous les inputs
   # launchd.user.agents.sketchyvim = {
@@ -51,7 +57,7 @@ in {
     skhdConfigFile = "${skhdModule.skhdConfig}/skhd-configuration";
   in {
     # Disabled: we run skhd via the .app wrapper so TCC permissions apply.
-    enable = false;
+    enable = true;
     skhdConfig = builtins.readFile skhdConfigFile;
   };
 
@@ -60,17 +66,6 @@ in {
       # Disabled by default; enable when using yabai.
       enable = false;
     };
-
-  # skhd via wrapper app (for reliable Accessibility/Input Monitoring)
-  launchd.user.agents.skhd-app = {
-    serviceConfig.ProgramArguments = [
-      "/Applications/Skhd.app/Contents/MacOS/Skhd"
-      "-c"
-      "/Users/alexandre.charlot/.skhdrc"
-    ];
-    serviceConfig.KeepAlive = true;
-    serviceConfig.RunAtLoad = true;
-  };
 
   # sketchybar is managed by home-manager program service
   # services.aerospace = (import ../configs/window-manager/aerospace.nix { inherit config pkgs; }) // {

--- a/nix/darwin/services.nix
+++ b/nix/darwin/services.nix
@@ -63,8 +63,7 @@ in {
 
   services.yabai =
     (import ../configs/window-manager/yabai.nix { inherit config; }) // {
-      # Disabled by default; enable when using yabai.
-      enable = false;
+      enable = true;
     };
 
   # sketchybar is managed by home-manager program service

--- a/nix/derivations/jankyBorders.nix
+++ b/nix/derivations/jankyBorders.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, darwin, gcc, make }:
+{ stdenv, fetchFromGitHub, darwin, gcc, make, apple-sdk_15 }:
 
 stdenv.mkDerivation rec {
   pname = "jankyBorders";
@@ -13,8 +13,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gcc ];
 
-  buildInputs =
-    [ darwin.apple_sdk.frameworks.AppKit darwin.apple_sdk.frameworks.SkyLight ];
+  buildInputs = [ apple-sdk_15 ];
+
+  NIX_LDFLAGS = "-F/System/Library/PrivateFrameworks -framework SkyLight";
 
   buildPhase = ''
     make

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -42,30 +42,38 @@ self: super: {
     };
   };
 
-  rift = super.stdenvNoCC.mkDerivation rec {
+  rift = super.rustPlatform.buildRustPackage rec {
     pname = "rift";
-    version = "0.3.9";
+    version = "0-unstable-2026-03-09";
 
-    src = super.fetchurl {
-      url = "https://github.com/acsandmann/rift/releases/download/v${version}/rift-universal-macos-${version}.tar.gz";
-      sha256 = "174yxnq3ks02jj8kfmv4sqxcdfswxcpm191fd50cx7pdy43a0mk9";
+    src = super.fetchFromGitHub {
+      owner = "acsandmann";
+      repo = "rift";
+      rev = "17eb725102f3bcc9f8e92b86a6c8be068bcdbf43";
+      hash = "sha256-vrfXXRDDnk556BYKBJjFD/RXDiVih3uz1OO/TPwZvgI=";
     };
 
-    dontBuild = true;
-    dontConfigure = true;
+    cargoLock = {
+      lockFile = src + "/Cargo.lock";
+      outputHashes = {
+        "continue-0.1.1" =
+          "sha256-8S+gPfz6CtzIKsGh9wg3CevMdNA9V+KOyHR9F9DlVcw=";
+        "dispatchr-1.0.0" =
+          "sha256-Df6PdDA5bpmy2P30vGdad+EiHJiANmHrRF2q75Uegik=";
+      };
+    };
 
-    unpackPhase = ''
-      tar -xzf $src
-    '';
+    buildInputs = [ super.apple-sdk_15 ];
 
-    installPhase = ''
-      mkdir -p $out/bin
-      cp rift $out/bin/
-      cp rift-cli $out/bin/
-    '';
+    # Link against macOS private frameworks
+    NIX_LDFLAGS =
+      "-F/System/Library/PrivateFrameworks -framework SkyLight -framework MultitouchSupport";
+
+    # Use default cargoInstallHook (handles cross-compile target paths)
 
     meta = with super.lib; {
-      description = "Rift is a fast, configurable tiling window manager for macOS";
+      description =
+        "Rift is a fast, configurable tiling window manager for macOS";
       homepage = "https://github.com/acsandmann/rift";
       license = licenses.mit;
       platforms = platforms.darwin;

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -42,15 +42,29 @@ self: super: {
     };
   };
 
+  yabai = super.yabai.overrideAttrs (finalAttrs: old: {
+    version = "7.1.23";
+    passthru = old.passthru // {
+      sources = old.passthru.sources // {
+        "aarch64-darwin" = super.fetchzip {
+          url =
+            "https://github.com/asmvik/yabai/releases/download/v${finalAttrs.version}/yabai-v${finalAttrs.version}.tar.gz";
+          hash = "sha256-p8LHuAhmkKNPkRNIw4NHpAA+/oQPMI34H21mlUiwK+M=";
+        };
+      };
+    };
+    src = finalAttrs.passthru.sources.${super.stdenv.hostPlatform.system};
+  });
+
   rift = super.rustPlatform.buildRustPackage rec {
     pname = "rift";
-    version = "0-unstable-2026-03-09";
+    version = "0-unstable-2026-04-15";
 
     src = super.fetchFromGitHub {
       owner = "acsandmann";
       repo = "rift";
-      rev = "17eb725102f3bcc9f8e92b86a6c8be068bcdbf43";
-      hash = "sha256-vrfXXRDDnk556BYKBJjFD/RXDiVih3uz1OO/TPwZvgI=";
+      rev = "27f5f00e7f40e7ba1b01cd25721b2545f255d42f";
+      hash = "sha256-JH6G5PWaR8Kw/hE4Rb6RvrkvBX6Hn4u1g+OFXE2Mmkc=";
     };
 
     cargoLock = {


### PR DESCRIPTION
- Build rift from latest main commit (ffa4825) instead of prebuilt release
- Update nixpkgs, nix-darwin, home-manager, nixvim to March 2026
- Migrate apple_sdk.frameworks to apple-sdk_15 (jankyBorders, rift)
- Fix removed packages: gitAndTools.delta -> delta, neofetch -> fastfetch
- Fix nvim-treesitter.configs removed API in newer treesitter